### PR TITLE
Install all dependencies required on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There is one dependency: `freetype`.
 Ubuntu:
 
 ```
-sudo apt install libfreetype6-dev
+sudo apt install libfreetype6-dev libx11-dev libxrandr-dev mesa-common-dev
 ```
 
 Fedora:


### PR DESCRIPTION
These additional dependencies are required to compile `ved` (Ubuntu 20.4).