### PR TITLE
ci: simplify on rules, fmt -verify ved.v and use to ./v

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - '**'
   pull_request:
-    branches:
-      - '**'
   schedule:
     - cron:  '31 1,12 * * *'
 
@@ -23,20 +19,15 @@ jobs:
       with:
         path: ved
     - name: Build V
-      run: |
-        make
-        sudo ./v symlink
+      run: make
     # - name: v vet
     #   run: |
     #     v vet .
     - name: v fmt -verify
       # v fmt -verify timer.v
-      # v fmt -verify ved.v
       run: |
         cd ved
-        v fmt -verify config.v
-        v fmt -verify query.v
-        v fmt -verify view.v
+        ../v fmt -verify config.v query.v ved.v view.v
 
   ubuntu:
     runs-on: ubuntu-20.04
@@ -54,13 +45,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install --quiet -y libfreetype6-dev libglfw3-dev libxi-dev libxcursor-dev
     - name: Build V
-      run: |
-        make
-        sudo ./v symlink
+      run: make
     - name: Build ved
       run: |
         cd ved
-        v -prod .
+        ../v -cc cc -prod .
 
   macos:
     runs-on: macos-10.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Build ved
       run: |
         cd ved
-        ../v .
+        ../v -cc cc .
         #v -prod .
 
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Build ved
       run: |
         cd ved
-        ../v -cc cc -prod .
+        ../v -prod .
 
   macos:
     runs-on: macos-10.15
@@ -67,13 +67,11 @@ jobs:
     - name: Build ved
       run: |
         cd ved
-        ../v -cc cc .
+        ../v .
         #v -prod .
 
   windows:
     runs-on: windows-2019
-    env:
-        VFLAGS: -cc gcc
     steps:
     - name: Checkout V
       uses: actions/checkout@v2
@@ -89,4 +87,4 @@ jobs:
     - name: Build ved
       run: |
         cd ved
-        ..\v.exe -cc cc -prod .
+        ..\v.exe -prod .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
 
   windows:
     runs-on: windows-2019
+    env:
+        VFLAGS: -cc gcc
     steps:
     - name: Checkout V
       uses: actions/checkout@v2
@@ -83,8 +85,8 @@ jobs:
         path: ved
     - name: Build V
       run: |
-        .\make.bat
+        .\make.bat -gcc
     - name: Build ved
       run: |
         cd ved
-        ..\v.exe -prod .
+        ..\v.exe -cc cc -prod .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,11 @@ jobs:
       with:
         path: ved
     - name: Build V
-      run: |
-        make
-        sudo ./v symlink
+      run: make
     - name: Build ved
       run: |
         cd ved
-        v .
+        ../v .
         #v -prod .
 
   windows:


### PR DESCRIPTION
<strike>- Pass `-cc cc` on ubuntu/mac and `-cc gcc` on WIndows because tcc is not good at building graphical apps</strike>
- use `../v` instead of symlinked V
- also verify formatting of `ved.v`
- simplify on rules