### PR TITLE
fix the patreon, workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Ved - small and fast text editor written in V
 
-[![Build Status][workflow-badge]][workflow-url]
-[![Patreon][patreon-badge]][patreon-url]
+[![Patreon-badge](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/vlang)
 
-<img width="640" src="https://user-images.githubusercontent.com/687996/63223411-807a7700-c1bd-11e9-82fc-e2362907024a.png">
+[![Workflow-badge](https://github.com/vlang/ved/workflows/CI/badge.svg)](https://github.com/vlang/ved/commits/master)
+
+<img width="640" src="https://user-images.githubusercontent.com/687996/63223411-807a7700-c1bd-11e9-82fc-e2362907024a.png"> 
 
 
 ### Building from source


### PR DESCRIPTION
There is a problem with the badge in the readme file

**Before** 

`![Build Status][workflow-badge] ![Patreon][patreon-badge]
`
![screenshot before](https://nimbus-screenshots.s3.amazonaws.com/s/a378d4c9129394e3ec9deb120e850b6f.png)

**After**

![screenshot after](https://nimbus-screenshots.s3.amazonaws.com/s/cc9f0cf08480ab0a6a057dff33653fb1.png)