### PR TITLE
uiold: remove unused global

### DIFF
--- a/uiold/ui_darwin.c.v
+++ b/uiold/ui_darwin.c.v
@@ -10,8 +10,6 @@ module uiold
 
 struct C.NSFont {}
 
-__global default_font &C.NSFont
-
 fn C.reg_key_vid2()
 
 pub fn reg_key_vid() {


### PR DESCRIPTION
This particular unused global requires an exception in the compiler on its own. Good riddance 😄