### PR TITLE
fix for vlang/v PR #10033

### DIFF
--- a/ved.v
+++ b/ved.v
@@ -20,6 +20,7 @@ const (
 	max_nr_workspaces = 10
 )
 
+[heap]
 struct Ved {
 mut:
 	win_width            int


### PR DESCRIPTION
This marks the Ved struct as `[heap]` to allow compiling after vlang/v PR [10033](https://github.com/vlang/v/pull/10033) is merged.