### PR TITLE
use `string.len_utf8()` instead of `utf8_str_len(string)`

### DIFF
--- a/ved.v
+++ b/ved.v
@@ -472,7 +472,7 @@ fn (mut ved Ved) draw_split(i int, split_from int) {
 		//}
 		// Handle utf8 codepoints
 		// old_len := s.len
-		if s.len != utf8_str_len(s) {
+		if s.len != s.len_utf8() {
 			u := s.runes()
 			if max > 0 && max < u.len {
 				s = u[..max].string()

--- a/ved.v
+++ b/ved.v
@@ -1829,7 +1829,7 @@ fn (ved &Ved) insert_task() ? {
 		return
 	}
 	start_time := time.unix(int(ved.task_start_unix))
-	mut f := os.open_append(tasks_path) ?
+	mut f := os.open_append(tasks_path)?
 	task_name := ved.cur_task.limit(max_task_len) +
 		strings.repeat(` `, max_task_len - ved.cur_task.len)
 	mins := ved.task_minutes().str() + 'm'
@@ -1838,7 +1838,7 @@ fn (ved &Ved) insert_task() ? {
 	if start_time.day == now.day && start_time.month == now.month {
 		// Single day entry
 		f.writeln('| $task_name | $mins $mins_pad | ' + start_time.format() + ' | ' +
-			time.now().hhmm() + ' |') ?
+			time.now().hhmm() + ' |')?
 	} else {
 		// Two day entry (separated by 00:00)
 		midnight := time.Time{
@@ -1857,12 +1857,12 @@ fn (ved &Ved) insert_task() ? {
 		}
 
 		f.writeln('| $task_name | $mins $mins_pad | ' + start_time.format() + ' | ' +
-			midnight.hhmm() + ' |') ?
-		f.writeln(separator) ?
+			midnight.hhmm() + ' |')?
+		f.writeln(separator)?
 		f.writeln('| $task_name | $mins $mins_pad | ' + day_start.format() + ' | ' +
-			time.now().hhmm() + ' |') ?
+			time.now().hhmm() + ' |')?
 	}
-	f.writeln(separator) ?
+	f.writeln(separator)?
 	f.close()
 }
 

--- a/view.v
+++ b/view.v
@@ -147,7 +147,7 @@ fn (mut view View) open_file(path string) {
 	view.hl_on = !view.path.ends_with('.md') && !view.path.ends_with('.txt')
 	view.changed = false
 	view.ved.gg.refresh_ui()
-	//go view.ved.write_changes_in_file_every_5s()
+	// go view.ved.write_changes_in_file_every_5s()
 }
 
 fn (mut view View) reopen() {


### PR DESCRIPTION
Fix notice:
```v
./ved.v:475:15: notice: function `utf8_str_len` will be deprecated after 2022-05-28, and will become an error after 2022-11-24; use `string.len_utf8()` instead
  473 |         // Handle utf8 codepoints
  474 |         // old_len := s.len
  475 |         if s.len != utf8_str_len(s) {
      |                     ~~~~~~~~~~~~~~~
  476 |             u := s.runes()
  477 |             if max > 0 && max < u.len {
```