### PR TITLE
Bug fixes, theme system

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Workflow-badge](https://github.com/vlang/ved/workflows/CI/badge.svg)](https://github.com/vlang/ved/commits/master)
 
-<img width="640" src="https://user-images.githubusercontent.com/687996/63223411-807a7700-c1bd-11e9-82fc-e2362907024a.png"> 
+<img width="640" src="https://user-images.githubusercontent.com/687996/63223411-807a7700-c1bd-11e9-82fc-e2362907024a.png">
 
 
 ### Building from source
@@ -86,7 +86,6 @@ This will be gradually fixed. The goal is to have a stable and highly customizab
 
 - No way to change key bindings, color settings, etc
 - Vim-mode only
-- No mouse support
 - No word wrap (I'm used to 80 character lines)
 - ~Only ASCII and Cyrillic letters are supported right now~
 

--- a/config.v
+++ b/config.v
@@ -51,12 +51,9 @@ fn (mut config Config) set_settings(path string) {
 	config.settings = toml.parse_file(path) or { toml.parse_text('') or { panic(err) } }
 }
 
-fn (mut config Config) init_colors() {
-	toml_dark_mode := config.settings.value('editor.dark_mode').bool()
-	config.dark_mode = toml_dark_mode || '-dark' in os.args
-}
-
 fn (mut config Config) reload_config() {
+	config.init_colors()
+
 	config.set_text_size()
 	config.set_line_height()
 	config.set_char_width()
@@ -78,6 +75,11 @@ fn (mut config Config) reload_config() {
 	config.set_line_nr()
 	config.set_green()
 	config.set_red()
+}
+
+fn (mut config Config) init_colors() {
+	toml_dark_mode := config.settings.value('editor.dark_mode').bool()
+	config.dark_mode = toml_dark_mode || '-dark' in os.args
 }
 
 fn (mut config Config) set_text_size() {

--- a/config.v
+++ b/config.v
@@ -23,7 +23,7 @@ mut:
 	split_color     gx.Color
 	bgcolor         gx.Color // base00
 	errorbgcolor    gx.Color // base08
-	title_color     gx.Color
+	title_color     gx.Color // base04
 	cursor_color    gx.Color // base05
 	string_color    gx.Color // base0B
 	string_cfg      gx.TextCfg
@@ -108,6 +108,20 @@ fn (mut config Config) set_backspace_behaviour() {
 	config.backspace_go_up = toml_backspace_behaviour
 }
 
+// Convert a toml key color (in hex) to a gx.Color type
+fn (config Config) get_toml_color(base string) !gx.Color {
+	toml_hex := config.settings.value('colors.base$base').string()
+	if toml_hex != 'toml.Any(toml.Null{})' {
+		toml_red := ('0x' + toml_hex[0..2]).u8()
+		toml_green := ('0x' + toml_hex[2..4]).u8()
+		toml_blue := ('0x' + toml_hex[4..6]).u8()
+
+		return gx.rgb(toml_red, toml_green, toml_blue)
+	}
+
+	return error('Couldn\'t read base$base from the settings file')
+}
+
 fn (mut config Config) set_vcolor() {
 	if !config.dark_mode {
 		config.vcolor = gx.rgb(226, 233, 241)
@@ -124,76 +138,78 @@ fn (mut config Config) set_split() {
 	}
 }
 
+// base 00
 fn (mut config Config) set_bgcolor() {
-	if !config.dark_mode {
-		config.bgcolor = gx.rgb(245, 245, 245)
-	} else {
-		config.bgcolor = gx.rgb(30, 30, 30)
+	config.bgcolor = config.get_toml_color('00') or {
+		if config.dark_mode {
+			gx.rgb(30, 30, 30)
+		} else {
+			gx.rgb(245, 245, 245)
+		}
 	}
 }
 
+// base 01
 fn (mut config Config) set_errorbgcolor() {
-	if !config.dark_mode {
-		config.errorbgcolor = gx.rgb(240, 0, 0)
-	} else {
-		config.errorbgcolor = gx.rgb(240, 0, 0)
-	}
+	config.errorbgcolor = config.get_toml_color('01') or { gx.rgb(240, 0, 0) }
 }
 
+// base 0B
 fn (mut config Config) set_string() {
-	if !config.dark_mode {
-		config.string_color = gx.rgb(179, 58, 44)
-	} else {
-		config.string_color = gx.rgb(179, 58, 44)
-	}
+	config.string_color = config.get_toml_color('0B') or { gx.rgb(179, 58, 44) }
+
 	config.string_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.string_color
 	}
 }
 
+// base 0E
 fn (mut config Config) set_key() {
-	if !config.dark_mode {
-		config.key_color = gx.rgb(74, 103, 154)
-	} else {
-		config.key_color = gx.rgb(74, 103, 154)
-	}
+	config.key_color = config.get_toml_color('0E') or { gx.rgb(74, 103, 154) }
+
 	config.key_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.key_color
 	}
 }
 
+// base 04
 fn (mut config Config) set_title() {
-	if !config.dark_mode {
-		config.title_color = gx.rgb(40, 40, 40)
-	} else {
-		config.title_color = gx.rgb(40, 40, 40)
-	}
+	config.title_color = config.get_toml_color('04') or { gx.rgb(40, 40, 40) }
 }
 
+// base 05
 fn (mut config Config) set_cursor() {
-	if !config.dark_mode {
-		config.cursor_color = gx.black
-	} else {
-		config.cursor_color = gx.white
+	config.cursor_color = config.get_toml_color('05') or {
+		if !config.dark_mode {
+			gx.black
+		} else {
+			gx.white
+		}
 	}
 }
 
+// base 05 (again)
 fn (mut config Config) set_txt() {
-	if !config.dark_mode {
-		config.text_color = gx.black
-	} else {
-		config.text_color = gx.rgb(212, 212, 212)
+	config.text_color = config.get_toml_color('05') or {
+		if !config.dark_mode {
+			gx.black
+		} else {
+			gx.rgb(212, 212, 212)
+		}
 	}
+
 	config.txt_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.text_color
 	}
 }
 
+// base 03
 fn (mut config Config) set_comment() {
-	config.comment_color = gx.dark_gray
+	config.comment_color = config.get_toml_color('03') or { gx.dark_gray }
+
 	config.comment_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.comment_color
@@ -224,8 +240,10 @@ fn (mut config Config) set_minus() {
 	}
 }
 
+// base 01
 fn (mut config Config) set_line_nr() {
-	config.line_nr_color = gx.dark_gray
+	config.line_nr_color = config.get_toml_color('01') or { gx.dark_gray }
+
 	config.line_nr_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.line_nr_color
@@ -233,8 +251,10 @@ fn (mut config Config) set_line_nr() {
 	}
 }
 
+// base 0B
 fn (mut config Config) set_green() {
-	config.green_color = gx.green
+	config.green_color = config.get_toml_color('0B') or { gx.green }
+
 	config.green_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.green_color
@@ -242,7 +262,7 @@ fn (mut config Config) set_green() {
 }
 
 fn (mut config Config) set_red() {
-	config.red_color = gx.red
+	config.red_color = config.get_toml_color('08') or { gx.red }
 	config.red_cfg = gx.TextCfg{
 		size: config.text_size
 		color: config.red_color

--- a/config.v
+++ b/config.v
@@ -21,17 +21,17 @@ mut:
 	backspace_go_up bool
 	vcolor          gx.Color
 	split_color     gx.Color
-	bgcolor         gx.Color
-	errorbgcolor    gx.Color
+	bgcolor         gx.Color // base00
+	errorbgcolor    gx.Color // base08
 	title_color     gx.Color
-	cursor_color    gx.Color
-	string_color    gx.Color
+	cursor_color    gx.Color // base05
+	string_color    gx.Color // base0B
 	string_cfg      gx.TextCfg
-	key_color       gx.Color
+	key_color       gx.Color // base0E
 	key_cfg         gx.TextCfg
-	text_color      gx.Color
+	text_color      gx.Color // base05
 	txt_cfg         gx.TextCfg
-	comment_color   gx.Color
+	comment_color   gx.Color // base03
 	comment_cfg     gx.TextCfg
 	file_name_color gx.Color
 	file_name_cfg   gx.TextCfg
@@ -39,11 +39,11 @@ mut:
 	plus_cfg        gx.TextCfg
 	minus_color     gx.Color
 	minus_cfg       gx.TextCfg
-	line_nr_color   gx.Color
+	line_nr_color   gx.Color // base01
 	line_nr_cfg     gx.TextCfg
-	green_color     gx.Color
+	green_color     gx.Color // base0B
 	green_cfg       gx.TextCfg
-	red_color       gx.Color
+	red_color       gx.Color // base08
 	red_cfg         gx.TextCfg
 }
 

--- a/query.v
+++ b/query.v
@@ -292,10 +292,10 @@ fn (mut ved Ved) draw_query() {
 	y := (ved.win_height - height) / 2
 	ved.gg.draw_rect_filled(x, y, width, height, gx.white)
 	// query window title
-	ved.gg.draw_rect_filled(x, y, width, ved.line_height, ved.cfg.title_color)
+	ved.gg.draw_rect_filled(x, y, width, ved.cfg.line_height, ved.cfg.title_color)
 	ved.gg.draw_text(x + 10, y, ved.query_type.str(), ved.cfg.file_name_cfg)
 	// query background
-	ved.gg.draw_rect_filled(0, 0, ved.win_width, ved.line_height, ved.cfg.title_color)
+	ved.gg.draw_rect_filled(0, 0, ved.win_width, ved.cfg.line_height, ved.cfg.title_color)
 	query_to_draw := if ved.query_type in [.search, .search_in_folder, .grep] {
 		ved.search_query
 	} else {

--- a/ved.v
+++ b/ved.v
@@ -165,7 +165,6 @@ fn main() {
 	ved.cfg.reload_config()
 
 	println('height=$size.height')
-	ved.page_height = size.height / ved.cfg.line_height - 1
 
 	keys_vlang :=
 		'case shared defer none match pub struct interface in sizeof assert enum import go ' +
@@ -270,6 +269,8 @@ fn main() {
 
 fn on_event(e &gg.Event, mut ved Ved) {
 	ved.refresh = true
+	ved.win_height = gg.window_size().height
+	ved.win_width = gg.window_size().width
 
 	if e.typ == .mouse_scroll {
 		if e.scroll_y < -0.2 {
@@ -307,7 +308,7 @@ fn on_event(e &gg.Event, mut ved Ved) {
 			}
 		}
 
-		view.y = int((e.mouse_y / ved.cfg.line_height - 1) / 2) + ved.view.from
+		view.y = int((e.mouse_y / ved.cfg.line_height - 1.5) / 2) + ved.view.from
 		// Wow, that's a lot of math that is probably pretty hard to parse.
 		// In the future I need to separate this into several variables,
 		// and perhaps even its own function.
@@ -348,8 +349,10 @@ fn frame(mut ved Ved) {
 }
 
 fn (mut ved Ved) draw() {
-	view := ved.view
+	mut view := ved.view
 	split_width := ved.split_width()
+	ved.page_height = ved.win_height / ved.cfg.line_height - 1
+	view.page_height = ved.page_height
 	// Splits from and to
 	from := ved.workspace_idx * ved.splits_per_workspace
 	to := from + ved.splits_per_workspace
@@ -702,19 +705,6 @@ fn (mut ved Ved) draw_text_line(x int, y int, line string) {
 	}
 }
 
-// mouse click
-// fn on_click(cwnd *C.GLFWwindow, button, action, mods int) {
-// wnd := glfw.Window {
-// data: cwnd
-// }
-// pos := wnd.get_cursor_pos()
-// println('CLICK $pos.x $pos.y')
-// mut ctx := &Ved(wnd.get_user_ptr())
-// printf("mouse click %p\n", glfw__Window_get_user_ptr(&wnd));
-// Mouse coords to x,y
-// ved.view.y = pos.y / line_height - 1
-// ved.view.x = (pos.x - ved.view.padding_left) / char_width - 1
-// }
 fn key_down(key gg.KeyCode, mod gg.Modifier, mut ved Ved) {
 	super := mod == .super
 	shift := mod == .shift

--- a/ved.v
+++ b/ved.v
@@ -140,10 +140,6 @@ fn main() {
 	mut size := gg.screen_size()
 	if size.width == 0 || size.height == 0 {
 		size = gg.Size{2560, 1480}
-		if '-laptop' in args {
-			size = gg.Size{1440 * 1, 900 * 1}
-			nr_splits = 1
-		}
 	}
 	mut ved := &Ved{
 		win_width: size.width

--- a/ved.v
+++ b/ved.v
@@ -293,6 +293,18 @@ fn on_event(e &gg.Event, mut ved Ved) {
 			}
 		}
 
+		// If the mouse is clicked outside of the current split, switch splits before continuing
+		for i := 0; i < ved.nr_splits; i++ {
+			sw := ved.split_width()
+			starting_x := 2 * i * sw
+			ending_x := 2 * (i + 1) * sw
+
+			if e.mouse_x > starting_x && e.mouse_x < ending_x {
+				ved.cur_split = i
+				ved.update_view()
+			}
+		}
+
 		view.y = int((e.mouse_y / ved.line_height - 1) / 2) + ved.view.from
 		// Wow, that's a lot of math that is probably pretty hard to parse.
 		// In the future I need to separate this into several variables,

--- a/ved.v
+++ b/ved.v
@@ -292,7 +292,7 @@ fn on_event(e &gg.Event, mut ved Ved) {
 			}
 		}
 
-		// If the mouse is clicked outside of the current split, switch splits before continuing
+		// Focus the pane currently under the cursor before continuing
 		for i := 0; i < ved.nr_splits; i++ {
 			sw := ved.split_width()
 			starting_x := 2 * i * sw
@@ -304,7 +304,21 @@ fn on_event(e &gg.Event, mut ved Ved) {
 			}
 		}
 
-		view.y = int((e.mouse_y / ved.cfg.line_height - 1.5) / 2) + ved.view.from
+		clicked_y := int((e.mouse_y / ved.cfg.line_height - 1.5) / 2) + ved.view.from
+		if clicked_y > view.lines.len {
+			if view.lines.len == 0 {
+				view.y = 0
+			} else {
+				view.y = view.lines.len - 1
+			}
+		} else if clicked_y < 0 {
+			view.y = 1
+		} else {
+			view.y = clicked_y
+		}
+
+		println('$clicked_y  ==>  $view.y')
+
 		// Wow, that's a lot of math that is probably pretty hard to parse.
 		// In the future I need to separate this into several variables,
 		// and perhaps even its own function.

--- a/ved.v
+++ b/ved.v
@@ -305,7 +305,7 @@ fn on_event(e &gg.Event, mut ved Ved) {
 		}
 
 		clicked_y := int((e.mouse_y / ved.cfg.line_height - 1.5) / 2) + ved.view.from
-		if clicked_y > view.lines.len {
+		if clicked_y >= view.lines.len {
 			if view.lines.len == 0 {
 				view.y = 0
 			} else {
@@ -316,8 +316,6 @@ fn on_event(e &gg.Event, mut ved Ved) {
 		} else {
 			view.y = clicked_y
 		}
-
-		println('$clicked_y  ==>  $view.y')
 
 		// Wow, that's a lot of math that is probably pretty hard to parse.
 		// In the future I need to separate this into several variables,

--- a/ved.v
+++ b/ved.v
@@ -156,8 +156,6 @@ fn main() {
 	ved.handle_segfault()
 
 	ved.cfg.set_settings(config_path)
-
-	ved.cfg.init_colors()
 	ved.cfg.reload_config()
 
 	println('height=$size.height')
@@ -918,6 +916,9 @@ fn (mut ved Ved) key_normal(key gg.KeyCode, mod gg.Modifier) {
 			if shift {
 				// <
 				ved.view.shift_left()
+			} else if super {
+				ved.cfg.reload_config()
+				ved.update_view()
 			}
 		}
 		.slash {
@@ -1142,10 +1143,7 @@ fn (mut ved Ved) key_normal(key gg.KeyCode, mod gg.Modifier) {
 				ved.view.l()
 			}
 		}
-		.f6 {
-			if super {
-			}
-		}
+		.f6 {}
 		.g {
 			// go to end
 			if shift && !super {

--- a/ved.v
+++ b/ved.v
@@ -308,7 +308,6 @@ fn on_event(e &gg.Event, mut ved Ved) {
 		}
 
 		view.y = int((e.mouse_y / ved.cfg.line_height - 1) / 2) + ved.view.from
-		view.y = int((e.mouse_y / ved.line_height - 1) / 2) + ved.view.from
 		// Wow, that's a lot of math that is probably pretty hard to parse.
 		// In the future I need to separate this into several variables,
 		// and perhaps even its own function.

--- a/ved.v
+++ b/ved.v
@@ -311,7 +311,17 @@ fn on_event(e &gg.Event, mut ved Ved) {
 		// Wow, that's a lot of math that is probably pretty hard to parse.
 		// In the future I need to separate this into several variables,
 		// and perhaps even its own function.
-		view.x = int(((e.mouse_x - ved.cur_split * ved.split_width() * 2 - view.padding_left) / ved.cfg.char_width) / 2 - 3 - leading_tabs * 3)
+		clicked_x := int(((e.mouse_x - ved.cur_split * ved.split_width() * 2 - view.padding_left) / ved.cfg.char_width) / 2 - 3 - leading_tabs * 3)
+		if view.lines.len <= 0 {
+			return
+		}
+		if clicked_x > view.lines[view.y].len {
+			view.x = view.lines[view.y].len
+		} else if clicked_x < 0 {
+			view.x = 0
+		} else {
+			view.x = clicked_x
+		}
 	}
 }
 
@@ -460,7 +470,8 @@ fn (mut ved Ved) draw() {
 		ved.gg.draw_rect_filled(cursor_x + ved.cfg.char_width, y - 1, 1, ved.cfg.line_height,
 			ved.cfg.cursor_color)
 	} else {
-		ved.gg.draw_rect_empty(cursor_x, y - 1, ved.cfg.char_width, ved.cfg.line_height, ved.cfg.cursor_color)
+		ved.gg.draw_rect_empty(cursor_x, y - 1, ved.cfg.char_width, ved.cfg.line_height,
+			ved.cfg.cursor_color)
 	}
 	// ved.gg.draw_text_def(cursor_x + 500, y - 1, 'tab=$cursor_tab_off x=$cursor_x view_x=$ved.view.x')
 	// query window

--- a/view.v
+++ b/view.v
@@ -400,11 +400,11 @@ fn (mut view View) insert_text(s string) {
 	if line.len == 0 {
 		view.set_line('$s ')
 	} else {
-		if view.x >= line.len {
+		if view.x > line.len {
 			view.x = line.len
 		}
 		uline := line.runes()
-		if view.x >= uline.len {
+		if view.x > uline.len {
 			return
 		}
 		left := uline[..view.x].string()

--- a/view.v
+++ b/view.v
@@ -133,7 +133,7 @@ fn (mut view View) open_file(path string) {
 	// Calc padding_left
 	nr_lines := view.lines.len
 	s := '$nr_lines'
-	view.padding_left = s.len * ved.char_width + 8
+	view.padding_left = s.len * ved.cfg.char_width + 8
 	view.ved.save_session()
 	// Go to old y for this file
 	y := view.ved.file_y_pos[view.path]


### PR DESCRIPTION
These commits do *tons* of stuff. Together, they have enabled me to use ved as my main editor working on ved (and other `v` stuff). Here's a quick rundown:

- Configurable settings (via `~/.ved/conf.toml`)
- Fix editing at end of line (unable to edit at end without appending to it via `A`)
- Fix mouse to start and end of line, fixing behaviour that would create segfaults by trying to edit text that was not there
- Fix clicking below the end of the file (only possible on short file), which used to cause segfaults
- Handle window resizes. There is still more work to do here, but it is miles better than it was before
- Create an initial theming system inside of the settings file. Use any base16 them in a toml-friendly form.
  - There is still more work to do here, but not much that can be done without changing the highlighting system. Therefore, this will take back seat to many other changes

One known issue that is caused by this PR is that when opening ved on a 4k display, ved first draws the titlebar and other elements at a smaller size and readjusts to the screen size on the first call to `draw()`.